### PR TITLE
Fixed Size GoVectors Pushing

### DIFF
--- a/vectors.go
+++ b/vectors.go
@@ -387,18 +387,17 @@ func (x *Vector) Push(y float64) {
 	return
 }
 
-func (x *Vector) PushFixed(y float64) {
+func (x *Vector) PushFixed(y float64) error {
 	lenx := len(*x)
-	//fmt.Printf("len %d cap: %d\n", lenx, cap(*x))
 	if lenx == cap(*x) {
 		slicex := (*x)[1:]
 
 		z := make([]float64, lenx, lenx)
 		copy(z, slicex)
 		z[lenx-1] = y
-		//fmt.Println(z)
 		*x = z
+		return nil
 	} else {
-		fmt.Printf("Vector len and cap different!", x)
+		return fmt.Errorf("GoVector len and cap different! %#v", x)
 	}
 }

--- a/vectors.go
+++ b/vectors.go
@@ -386,3 +386,19 @@ func (x *Vector) Push(y float64) {
 	*x = append(*x, y)
 	return
 }
+
+func (x *Vector) PushFixed(y float64) {
+	lenx := len(*x)
+	//fmt.Printf("len %d cap: %d\n", lenx, cap(*x))
+	if lenx == cap(*x) {
+		slicex := (*x)[1:]
+
+		z := make([]float64, lenx, lenx)
+		copy(z, slicex)
+		z[lenx-1] = y
+		//fmt.Println(z)
+		*x = z
+	} else {
+		fmt.Printf("Vector len and cap different!", x)
+	}
+}

--- a/vectors_test.go
+++ b/vectors_test.go
@@ -1,6 +1,7 @@
 package govector
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/bmizerany/assert"
@@ -79,4 +80,19 @@ func TestVectors(t *testing.T) {
 
 	x.Sort()
 	assert.Equal(t, Vector{2, 2, 2, 2, 4, 5, 50}, x)
+}
+
+func TestFixedPush(t *testing.T) {
+	arr := make([]float64, 3, 3)
+
+	v := Vector(arr)
+	v.PushFixed(5.0)
+	v.PushFixed(25.0)
+	v.PushFixed(125.0)
+	fmt.Printf("%#v\n", v)
+	assert.Equal(t, v[2], 125.0)
+
+	v.PushFixed(250.0)
+	assert.Equal(t, v[2], 250.0)
+	assert.Equal(t, v[0], 25.0)
 }

--- a/vectors_test.go
+++ b/vectors_test.go
@@ -1,7 +1,6 @@
 package govector
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/bmizerany/assert"
@@ -89,10 +88,10 @@ func TestFixedPush(t *testing.T) {
 	v.PushFixed(5.0)
 	v.PushFixed(25.0)
 	v.PushFixed(125.0)
-	fmt.Printf("%#v\n", v)
 	assert.Equal(t, v[2], 125.0)
 
 	v.PushFixed(250.0)
 	assert.Equal(t, v[2], 250.0)
 	assert.Equal(t, v[0], 25.0)
+	assert.Equal(t, len(v), 3)
 }

--- a/vectors_test.go
+++ b/vectors_test.go
@@ -85,13 +85,15 @@ func TestFixedPush(t *testing.T) {
 	arr := make([]float64, 3, 3)
 
 	v := Vector(arr)
-	v.PushFixed(5.0)
-	v.PushFixed(25.0)
-	v.PushFixed(125.0)
+	err := v.PushFixed(5.0)
+	err = v.PushFixed(25.0)
+	err = v.PushFixed(125.0)
 	assert.Equal(t, v[2], 125.0)
 
-	v.PushFixed(250.0)
-	assert.Equal(t, v[2], 250.0)
-	assert.Equal(t, v[0], 25.0)
+	err = v.PushFixed(250.0)
+	err = v.PushFixed(350.0)
+	assert.Equal(t, err, nil)
+	assert.Equal(t, v[2], 350.0)
+	assert.Equal(t, v[0], 125.0)
 	assert.Equal(t, len(v), 3)
 }


### PR DESCRIPTION
The PushFixed function will not increase the size of the GoVector. The oldest values will simply be dropped off the vector. Uses a somewhat naive copy instead of a more efficient sliding window, but its better than continuing to expand the array memory structures.

Performance could be improved if necessary with a sliding window array implementation.

Only an addition of functionality, tests pass.