### PR TITLE
Pushfixed handles expansion

### DIFF
--- a/vectors.go
+++ b/vectors.go
@@ -386,3 +386,19 @@ func (x *Vector) Push(y float64) {
 	*x = append(*x, y)
 	return
 }
+
+//Append values to an array. Array size will not grow if unnecessary.
+//It will grow if the cap has been extended by external modification.
+func (x *Vector) PushFixed(y float64) error {
+	lenx := len(*x)
+	if lenx <= cap(*x) {
+		slicex := (*x)[1:]
+		z := make([]float64, lenx, lenx)
+		copy(z, slicex)
+		z[lenx-1] = y
+		*x = z
+		return nil
+	} else {
+		return fmt.Errorf("GoVector length greater than capacity!? len: %d cap: %d\n%#v", len(*x), cap(*x), x)
+	}
+}


### PR DESCRIPTION
Improvement to the PushFixed function.

It will now gracefully handle the case that the array had it's capacity expanded by an append command which doubles the array's size. `Push` and `PushFixed` can now be called interchangeably without error. 

It does mean that memory usage can leak if code does not stringently use the PushFixed method.